### PR TITLE
Add basic setup information in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,97 +1,67 @@
-<!-- AUTO-GENERATED-CONTENT:START (STARTER) -->
-<p align="center">
-  <a href="https://www.gatsbyjs.org">
-    <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
-  </a>
-</p>
-<h1 align="center">
-  Gatsby's default starter
-</h1>
+# Devpendent Website 🏍
 
-Kick off your project with this default boilerplate. This starter ships with the main Gatsby configuration files you might need to get up and running blazing fast with the blazing fast app generator for React.
+👨🏻‍💻 An Open Sourced Platform for Indonesian Election Real Count<br>
+💻 [Live site](https://devpendent.netlify.com/)
 
-_Have another more specific idea? You may want to check out our vibrant collection of [official and community-created starters](https://www.gatsbyjs.org/docs/gatsby-starters/)._
+## Installation
 
-## 🚀 Quick start
+1. Make sure [yarn](https://yarnpkg.com) is installed in your local machine.
+2. Clone this project and run `yarn` in the project's root directory.
 
-1.  **Create a Gatsby site.**
+```sh
+$ git clone git@github.com:devpendent/website.git
+$ cd website
+$ yarn
+```
 
-    Use the Gatsby CLI to create a new site, specifying the default starter.
+## Available Scripts
 
-    ```sh
-    # create a new Gatsby site using the default starter
-    gatsby new my-default-starter https://github.com/gatsbyjs/gatsby-starter-default
-    ```
+In the project's root directory, you can run:
 
-1.  **Start developing.**
+### Development
 
-    Navigate into your new site’s directory and start it up.
+#### `yarn develop`
 
-    ```sh
-    cd my-default-starter/
-    gatsby develop
-    ```
+Runs the app in the development mode.<br>
+The app will be running at `http://localhost:8000`!
 
-1.  **Open the source code and start editing!**
+_Note: You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-five/#introducing-graphiql)._
 
-    Your site is now running at `http://localhost:8000`!
+Open the `website` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
 
-    _Note: You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-five/#introducing-graphiql)._
+#### `yarn start`
 
-    Open the `my-default-starter` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
+Just an alias `yarn develop`, for you who are used to type `yarn start` instead. 😁
 
-## 🧐 What's inside?
+### Building
 
-A quick look at the top-level files and directories you'll see in a Gatsby project.
+#### `yarn build`
 
-    .
-    ├── node_modules
-    ├── src
-    ├── .gitignore
-    ├── .prettierrc
-    ├── gatsby-browser.js
-    ├── gatsby-config.js
-    ├── gatsby-node.js
-    ├── gatsby-ssr.js
-    ├── LICENSE
-    ├── package-lock.json
-    ├── package.json
-    └── README.md
+Builds the app for production to the `public` folder.<br>
 
-1.  **`/node_modules`**: This directory contains all of the modules of code that your project depends on (npm packages) are automatically installed.
+#### `yarn serve`
 
-2.  **`/src`**: This directory will contain all of the code related to what you will see on the front-end of your site (what you see in the browser) such as your site header or a page template. `src` is a convention for “source code”.
+Serves the built assets from the `yarn:build` command above.
 
-3.  **`.gitignore`**: This file tells git which files it should not track / not maintain a version history for.
+### Testing
 
-4.  **`.prettierrc`**: This is a configuration file for [Prettier](https://prettier.io/). Prettier is a tool to help keep the formatting of your code consistent.
+#### `yarn test`
 
-5.  **`gatsby-browser.js`**: This file is where Gatsby expects to find any usage of the [Gatsby browser APIs](https://www.gatsbyjs.org/docs/browser-apis/) (if any). These allow customization/extension of default Gatsby settings affecting the browser.
+Launches the test runner in the interactive watch mode.<br>
+See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
-6.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby site. This is where you can specify information about your site (metadata) like the site title and description, which Gatsby plugins you’d like to include, etc. (Check out the [config docs](https://www.gatsbyjs.org/docs/gatsby-config/) for more detail).
+### Formatting
 
-7.  **`gatsby-node.js`**: This file is where Gatsby expects to find any usage of the [Gatsby Node APIs](https://www.gatsbyjs.org/docs/node-apis/) (if any). These allow customization/extension of default Gatsby settings affecting pieces of the site build process.
+#### `yarn format`
 
-8.  **`gatsby-ssr.js`**: This file is where Gatsby expects to find any usage of the [Gatsby server-side rendering APIs](https://www.gatsbyjs.org/docs/ssr-apis/) (if any). These allow customization of default Gatsby settings affecting server-side rendering.
+Manually triggers Prettier format & ESLint fix towards all `js` & `json` files.
+By default it has to be run automatically on save in your IDE (for Visual Studio Code users, the configurations are already included in this project).
 
-9.  **`LICENSE`**: Gatsby is licensed under the MIT license.
+It also will be run each time before you commit (pre-commit hook).
+This way, we can prevent unformatted file to be committed to the repository.
 
-10. **`package-lock.json`** (See `package.json` below, first). This is an automatically generated file based on the exact versions of your npm dependencies that were installed for your project. **(You won’t change this file directly).**
+## License
 
-11. **`package.json`**: A manifest file for Node.js projects, which includes things like metadata (the project’s name, author, etc). This manifest is how npm knows which packages to install for your project.
+© Copyright 2019 Devpendent Team, The MIT License (MIT).
 
-12. **`README.md`**: A text file containing useful reference information about your project.
-
-## 🎓 Learning Gatsby
-
-Looking for more guidance? Full documentation for Gatsby lives [on the website](https://www.gatsbyjs.org/). Here are some places to start:
-
-- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://www.gatsbyjs.org/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
-
-- **To dive straight into code samples, head [to our documentation](https://www.gatsbyjs.org/docs/).** In particular, check out the _Guides_, _API Reference_, and _Advanced Tutorials_ sections in the sidebar.
-
-## 💫 Deploy
-
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-default)
-
-<!-- AUTO-GENERATED-CONTENT:END -->
+For more information, see the LICENSE file in this directory.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@devpendent/website",
-  "private": true,
-  "description": "Open Sourced Platform for Indonesian Election Real Count",
+  "private": false,
+  "description": "An Open Sourced Platform for Indonesian Election Real Count",
   "version": "0.1.0",
   "author": "Zain Fathoni <zain.fathoni@gmail.com>",
   "dependencies": {
@@ -80,10 +80,12 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
     "develop": "gatsby develop",
-    "format": "prettier --write src/**/*.{js,jsx}",
-    "start": "npm run develop",
+    "start": "yarn develop",
+    "format:prettier": "prettier-standard --write {src/**/*,gatsby-*}.{js,json}",
+    "format:lint": "eslint --ignore-path .gitignore --fix {src/**/*,gatsby-*}.js",
+    "format": "yarn format:prettier && yarn format:lint",
+    "build": "gatsby build",
     "serve": "gatsby serve",
     "test": "jest"
   },


### PR DESCRIPTION
The default `README.md` content from Gatsby is already moved to [the wiki](https://github.com/devpendent/website/wiki/gatsby)