### PR TITLE
Extend RenovateBot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
-    ":assignAndReview(zainfathoni,ri7nz)"
+    ":assignAndReview(zainfathoni,ri7nz)",
+    ":label(chore)"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":assignAndReview(zainfathoni,ri7nz)"
   ]
 }


### PR DESCRIPTION
- [x] Use [:assignAndReview](https://renovatebot.com/docs/presets-default/#assignandreviewltarg0gt) config preset to automatically assign and request reviews from admins to Renovate's PRs
- [x] Use [:label](https://renovatebot.com/docs/presets-default/#labelltarg0gt) config preset to  automatically label Renovate's PR as a chore