### PR TITLE
Add Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!
+
+Please fill out the information below to expedite the review and (hopefully)
+merge of your pull request!
+-->
+
+<!-- What changes are being made? (What feature/bug is being fixed here?) -->
+
+**What**:
+
+<!-- Why are these changes necessary? -->
+
+**Why**:
+
+<!-- How were these changes implemented? -->
+
+**How**:
+
+<!-- Have you done all of these things?  -->
+
+**Checklist**:
+
+<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
+
+<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
+
+- [ ] Tests
+- [ ] Ready to be merged
+      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
+
+<!-- feel free to add additional comments -->


### PR DESCRIPTION
Add a simple Pull Request template to meet the [recommended community standards](https://opensource.guide/), as shown in this project's [Community](https://github.com/devpendent/website/community) page.

**What**: Add a basic Pull Request template

**Why**: To meet the [recommended community standards](https://opensource.guide/), as shown in this project's [Community]

**How**: By following [this tutorial](https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository)

**Checklist**:

- [x] Tests
- [x] Ready to be merged