### PR TITLE
Fix :assignAndReview preset config usage in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    ":assignAndReview(zainfathoni,ri7nz)",
+    ":assignAndReview(zainfathoni)",
+    ":assignAndReview(ri7nz)",
     ":label(chore)"
   ]
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Assign & Request for review to @ri7nz as well

<!-- Why are these changes necessary? -->

**Why**: So that both of us (@zainfathoni & @ri7nz) are notified

<!-- How were these changes implemented? -->

**How**: Applying the preset config twice with a single argument instead of once with 2 arguments

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~Tests~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
