### PR TITLE
Fix assignees & reviewers list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "config:base",
-    ":assignAndReview(zainfathoni)",
-    ":assignAndReview(ri7nz)",
-    ":label(chore)"
-  ]
+  "extends": ["config:base", ":label(chore)"],
+  "assignees": ["zainfathoni", "ri7nz"],
+  "reviewers": ["zainfathoni", "ri7nz"]
 }


### PR DESCRIPTION
# Fix assignees & reviewers list

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix assignees & reviewers list

<!-- Why are these changes necessary? -->

**Why**: It turns out that the ':assignAndReview' config preset overrides the previous value set.

<!-- How were these changes implemented? -->

**How**: So let's try adding the assignees and reviewers manually without any config preset.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~Tests~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
