### PR TITLE
Make Renovate Bot automatically merge PR if all status checks passed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base", ":label(chore)"],
+  "automerge": true,
   "assignees": ["zainfathoni", "ri7nz"],
   "reviewers": ["zainfathoni", "ri7nz"]
 }


### PR DESCRIPTION
# Make Renovate Bot automatically merge PR if all status checks passed

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Make Renovate Bot automatically merge PR if all status checks passed

<!-- Why are these changes necessary? -->

**Why**: Merging Renovate Bot PRs manually takes too much time.

<!-- How were these changes implemented? -->

**How**: https://renovatebot.com/docs/configuration-options/#automerge

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
