### PR TITLE
Fix Renovate default assignee & reviewer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
-  "extends": ["config:base", ":label(chore)"],
-  "automerge": true,
-  "assignees": ["zainfathoni", "ri7nz"],
-  "reviewers": ["zainfathoni", "ri7nz"]
+  "extends": ["config:base", ":assignAndReview(zainfathoni)", ":label(chore)"],
+  "automerge": true
 }


### PR DESCRIPTION
# Fix Renovate default assignee & reviewer

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix Renovate default assignee & reviewer

<!-- Why are these changes necessary? -->

**Why**: Because the current configuration failed to assign & request for reviews to both @zainfathoni & @ri7nz 

<!-- How were these changes implemented? -->

**How**: Use `:assignAndReview` config preset again for 1 user instead of 2 users

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
