### PR TITLE
Refactor StaticQuery to hooks

### DIFF
--- a/src/components/__tests__/__snapshots__/layout.test.js.snap
+++ b/src/components/__tests__/__snapshots__/layout.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Image renders correctly 1`] = `
+exports[`Layout renders correctly 1`] = `
 <div>
   <header
     style="background: rebeccapurple; margin-bottom: 1.45rem;"

--- a/src/components/__tests__/image.test.js
+++ b/src/components/__tests__/image.test.js
@@ -1,27 +1,26 @@
-import { StaticQuery } from 'gatsby'
+import { useStaticQuery } from 'gatsby'
 import React from 'react'
 import { render } from 'react-testing-library'
 import Image from '../image'
 
 describe('Image', () => {
   beforeEach(() => {
-    StaticQuery.mockImplementationOnce(({ render }) =>
-      render({
-        placeholderImage: {
-          childImageSharp: {
-            fluid: {
-              aspectRatio: 1,
-              base64:
-                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAAsSAAALEgHS3X78AAACYklEQVQ4y42Uy28SQRjA+dM8efDmwYN6qF6qiSY+Y/WgQRMibY00TaWNBSRSCraYQtHl/bR0KyxQWCgWWAqU8izl/Sq7rLNsRHlVJpvJtzPfb77nDIOcZHSoqZSrp4+KtXIziubaLRysMCZiCYqOoVnhjNEi8RcztdxxeTzc6VBfT+5O2Vhpb+vw4wMdZ0ppWvP9xzLeJoDNThf2W+Nz1+XzNxQubSToSKKW+BDc+WOnkshhSVgeCiGpViZMEg1oxc26Knt+ae3bEtJTZwzE1kXLccG0+sOOlrcvZXvsczPkITfsa20vwIKnhsh+BnjUarT74Gb13CY7KBVJMv3z4N1NszQYsMWM62HNrCis/GxXn0iYls23uz5LPBcv0bH8hUH2XRoM85ySXv7JBtO87jMIvWq+H5GoYIHCLA1ZxD6Qap3Ak8IKfW7TJ50lK6uP9E6RgndHaODtCJ6Z5RyHfnE7j6gRbcKlCYNSt+rtETHTpUGgEP8FYmdNqd/Mo7aiVWTfuH2L9xASvfxxlqr01EYkrJszvNkgW9bH0OuFr+99m+y9IOeyU6zIp/Hubp/yMEztlzFPwOhdvq+nIoS1JNn4t2sugCmVsDvPe2KKolnZLCxhOcAKQRDDXTQaVi46lqYhIBwHTrl3oWqhMRDtaJge37lOBMKo4tfbqhVX0J7snTsWps8uZWuoOQY6CcjpSIF55UvmqNgr5wUwtV1IVdnXtnSfPEB2qjDNqnvczRl0m+j6Jn5lXb6nAQJqinmN0ZEBj03YLzghY8PnTRz80o/GRJZpOLCb0PM9BN7pvUEjx28V00WUg9jIVwAAAABJRU5ErkJggg==',
-              sizes: '(max-width: 300px) 100vw, 300px',
-              src:
-                '/static/6d91c86c0fde632ba4cd01062fd9ccfa/fbe2f/gatsby-astronaut.png',
-              srcSet:
-                '/static/6d91c86c0fde632ba4cd01062fd9ccfa/e1fed/gatsby-astronaut.png 75w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/08283/gatsby-astronaut.png 150w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/fbe2f/gatsby-astronaut.png 300w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/59257/gatsby-astronaut.png 450w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/26d9e/gatsby-astronaut.png 600w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/a3fa0/gatsby-astronaut.png 800w'
-            }
+    useStaticQuery.mockReturnValueOnce({
+      placeholderImage: {
+        childImageSharp: {
+          fluid: {
+            aspectRatio: 1,
+            base64:
+              'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAAsSAAALEgHS3X78AAACYklEQVQ4y42Uy28SQRjA+dM8efDmwYN6qF6qiSY+Y/WgQRMibY00TaWNBSRSCraYQtHl/bR0KyxQWCgWWAqU8izl/Sq7rLNsRHlVJpvJtzPfb77nDIOcZHSoqZSrp4+KtXIziubaLRysMCZiCYqOoVnhjNEi8RcztdxxeTzc6VBfT+5O2Vhpb+vw4wMdZ0ppWvP9xzLeJoDNThf2W+Nz1+XzNxQubSToSKKW+BDc+WOnkshhSVgeCiGpViZMEg1oxc26Knt+ae3bEtJTZwzE1kXLccG0+sOOlrcvZXvsczPkITfsa20vwIKnhsh+BnjUarT74Gb13CY7KBVJMv3z4N1NszQYsMWM62HNrCis/GxXn0iYls23uz5LPBcv0bH8hUH2XRoM85ySXv7JBtO87jMIvWq+H5GoYIHCLA1ZxD6Qap3Ak8IKfW7TJ50lK6uP9E6RgndHaODtCJ6Z5RyHfnE7j6gRbcKlCYNSt+rtETHTpUGgEP8FYmdNqd/Mo7aiVWTfuH2L9xASvfxxlqr01EYkrJszvNkgW9bH0OuFr+99m+y9IOeyU6zIp/Hubp/yMEztlzFPwOhdvq+nIoS1JNn4t2sugCmVsDvPe2KKolnZLCxhOcAKQRDDXTQaVi46lqYhIBwHTrl3oWqhMRDtaJge37lOBMKo4tfbqhVX0J7snTsWps8uZWuoOQY6CcjpSIF55UvmqNgr5wUwtV1IVdnXtnSfPEB2qjDNqnvczRl0m+j6Jn5lXb6nAQJqinmN0ZEBj03YLzghY8PnTRz80o/GRJZpOLCb0PM9BN7pvUEjx28V00WUg9jIVwAAAABJRU5ErkJggg==',
+            sizes: '(max-width: 300px) 100vw, 300px',
+            src:
+              '/static/6d91c86c0fde632ba4cd01062fd9ccfa/fbe2f/gatsby-astronaut.png',
+            srcSet:
+              '/static/6d91c86c0fde632ba4cd01062fd9ccfa/e1fed/gatsby-astronaut.png 75w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/08283/gatsby-astronaut.png 150w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/fbe2f/gatsby-astronaut.png 300w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/59257/gatsby-astronaut.png 450w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/26d9e/gatsby-astronaut.png 600w,\n/static/6d91c86c0fde632ba4cd01062fd9ccfa/a3fa0/gatsby-astronaut.png 800w'
           }
         }
-      }))
+      }
+    })
   })
 
   it('renders correctly', () => {

--- a/src/components/__tests__/layout.test.js
+++ b/src/components/__tests__/layout.test.js
@@ -1,20 +1,19 @@
-import { StaticQuery } from 'gatsby'
+import { useStaticQuery } from 'gatsby'
 import React from 'react'
 import { render } from 'react-testing-library'
 import Layout from '../layout'
 
-describe('Image', () => {
+describe('Layout', () => {
   beforeEach(() => {
-    StaticQuery.mockImplementationOnce(({ render }) =>
-      render({
-        site: {
-          siteMetadata: {
-            desciption:
-              'An Open Sourced Platform for Indonesia Election Real Count',
-            title: 'Devpendent'
-          }
+    useStaticQuery.mockReturnValueOnce({
+      site: {
+        siteMetadata: {
+          desciption:
+            'An Open Sourced Platform for Indonesia Election Real Count',
+          title: 'Devpendent'
         }
-      }))
+      }
+    })
   })
 
   it('renders correctly', () => {

--- a/src/components/image.js
+++ b/src/components/image.js
@@ -1,4 +1,4 @@
-import { StaticQuery, graphql } from 'gatsby'
+import { graphql, useStaticQuery } from 'gatsby'
 import Img from 'gatsby-image'
 import React from 'react'
 
@@ -13,9 +13,9 @@ import React from 'react'
  * - `StaticQuery`: https://gatsby.dev/staticquery
  */
 
-const Image = () => (
-  <StaticQuery
-    query={graphql`
+const Image = () => {
+  const data = useStaticQuery(
+    graphql`
       query {
         placeholderImage: file(relativePath: { eq: "gatsby-astronaut.png" }) {
           childImageSharp {
@@ -25,8 +25,10 @@ const Image = () => (
           }
         }
       }
-    `}
-    render={data => <Img fluid={data.placeholderImage.childImageSharp.fluid} />}
-  />
-)
+    `
+  )
+
+  return <Img fluid={data.placeholderImage.childImageSharp.fluid} />
+}
+
 export default Image

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -6,49 +6,47 @@
  */
 
 import Header from 'components/header'
-import { StaticQuery, graphql } from 'gatsby'
+import { graphql, useStaticQuery } from 'gatsby'
 import PropTypes from 'prop-types'
 import React from 'react'
 import './layout.css'
 
-const Layout = ({ children }) => (
-  <StaticQuery
-    query={graphql`
-      query SiteTitleQuery {
-        site {
-          siteMetadata {
-            title
-            description
-          }
+const Layout = ({ children }) => {
+  const {
+    site: {
+      siteMetadata: { description, title }
+    }
+  } = useStaticQuery(graphql`
+    query SiteTitleQuery {
+      site {
+        siteMetadata {
+          title
+          description
         }
       }
-    `}
-    render={({
-      site: {
-        siteMetadata: { title, description }
-      }
-    }) => (
-      <>
-        <Header siteTitle={title} description={description} />
-        <div
-          style={{
-            margin: `0 auto`,
-            maxWidth: 960,
-            padding: `0px 1.0875rem 1.45rem`,
-            paddingTop: 0
-          }}
-        >
-          <main>{children}</main>
-          <footer>
-            © {new Date().getFullYear()}, Built with
-            {` `}
-            <a href='https://www.gatsbyjs.org'>Gatsby</a>
-          </footer>
-        </div>
-      </>
-    )}
-  />
-)
+    }
+  `)
+  return (
+    <>
+      <Header siteTitle={title} description={description} />
+      <div
+        style={{
+          margin: `0 auto`,
+          maxWidth: 960,
+          padding: `0px 1.0875rem 1.45rem`,
+          paddingTop: 0
+        }}
+      >
+        <main>{children}</main>
+        <footer>
+          © {new Date().getFullYear()}, Built with
+          {` `}
+          <a href='https://www.gatsbyjs.org'>Gatsby</a>
+        </footer>
+      </div>
+    </>
+  )
+}
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired


### PR DESCRIPTION
# Refactor StaticQuery to hooks

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Always `useStaticQuery` hook instead of using `StaticQuery` render props

<!-- Why are these changes necessary? -->

**Why**: For the sake of consistency

<!-- How were these changes implemented? -->

**How**: By refactoring `Layout` & `Image` components implementations & tests

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
