### PR TITLE
Disable Cypress Dashboard recording due to free-tier limitation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
           requires:
             - cypress/install
           yarn: true # use yarn
-          record: true # record results on Cypress Dashboard
+          record: false # record results on Cypress Dashboard
           parallel: true # split all specs across machines
           parallelism: 3 # use 3 CircleCI machines to finish quickly
           group: e2e tests # name this group "all tests" on the dashboard


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Disable Cypress Dashboard recording due to free-tier limitation

<!-- Why are these changes necessary? -->

**Why**: Our Cypress free **Seed Plan** only covers a limited number of monthly test runs which we have exceeded.

<!-- How were these changes implemented? -->

**How**: By disabling the `record` option in [Cypress CircleCI Orb](https://github.com/cypress-io/circleci-orb#record-on-dashboard)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
